### PR TITLE
Support for `restricted_token`

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ const auth = (req, res, next) => {
     req.session.sessionToken = req.headers['x-tidepool-session-token'];
   }
 
-  if (!_.hasIn(req.session, 'sessionToken')) {
+  if (!_.hasIn(req.session, 'sessionToken') && !_.hasIn(req.query, 'restricted_token')) {
     return res.redirect('/login');
   }
 
@@ -52,11 +52,14 @@ const auth = (req, res, next) => {
 };
 
 function buildHeaders(requestSession) {
-  return {
-    headers: {
-      'x-tidepool-session-token': requestSession.sessionToken,
-    },
-  };
+  if (requestSession.sessionToken) {
+    return {
+      headers: {
+        'x-tidepool-session-token': requestSession.sessionToken,
+      },
+    };
+  }
+  return {};
 }
 
 function getPatientNameFromProfile(profile) {
@@ -112,6 +115,10 @@ app.get('/export/:env/:userid', auth, async (req, res) => {
   if (req.query.endDate) {
     queryData.endDate = req.query.endDate;
     logString += ` until ${req.query.endDate}`;
+  }
+  if (req.query.restricted_token) {
+    queryData.restricted_token = req.query.restricted_token;
+    logString += ' with restricted_token';
   }
   log.info(logString);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-data-export-service",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "app.js",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@tidepool/data-tools": "1.0.1",
+    "@tidepool/data-tools": "1.0.2",
     "JSONStream": "1.3.1",
     "axios": "0.17.1",
     "body-parser": "1.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@tidepool/data-tools@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tidepool/data-tools/-/data-tools-1.0.1.tgz#8d5fb4af58782d02ab679c3ac8abfae756fa3cff"
+"@tidepool/data-tools@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tidepool/data-tools/-/data-tools-1.0.2.tgz#606c0afd7a1b707dbaf7f9b89e569d4eeea28ec9"
   dependencies:
     JSONStream "1.1.2"
     chalk "1.1.3"


### PR DESCRIPTION
Allow `restricted_token` query parameter as potential authenticated request and pass that along to the API endpoint.

note: depends on https://trello.com/c/hrwoXANO/437-update-tide-whisperer-to-understand-restricted-tokens